### PR TITLE
fix: mikuではなかった場合の戻り値1を返す

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,4 @@
+import sys
 import argparse
 from model.predict import load_model, predict
 from utils.download import download_image
@@ -14,11 +15,15 @@ def main():
     pred, conf = predict(model, image)
 
     if pred is None:
-        print("failed")
+        print("Prediction failed.", file=sys.stderr)
+        sys.exit(255)
+    elif pred != 0:
+        label = "Miku isn't in a picture."
+        print(f"{label} (Confidence: {conf:.2f})", file=sys.stderr)
+        sys.exit(1)
     else:
-        label = "Miku is in a picture!" if pred == 0 else "Miku isn't in a picture."
+        label = "Miku is in a picture!"
         print(f"{label} (Confidence: {conf:.2f})")
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
成功のステータス場合のみに対象のコマンド実行に渡せるようにできるようにする

```bash
python3 cli.py "https://cdn.donmai.us/original/23/36/__hatsune_miku_and_hatsune_miku_vocaloid_drawn_by_asai_masaki__2336511bf032970529136272f8e881b0.png" && echo test
```